### PR TITLE
Fix: Resolve infinite scroll and rollback issue

### DIFF
--- a/src/app/components/data-table/data-table.tsx
+++ b/src/app/components/data-table/data-table.tsx
@@ -42,9 +42,6 @@ export default function DataTable<T>({
         return windowSize.height - (60 + padding)
     }, [windowSize.height])
 
-    // Добавляем ref для отслеживания состояния загрузки
-    const isLoadingRef = useRef(false);
-
     const {rows} = table.getRowModel()
 
 
@@ -52,7 +49,7 @@ export default function DataTable<T>({
 
     const fetchMoreOnBottomReached = useCallback(
         async (containerRefElement?: HTMLDivElement | null) => {
-            if (containerRefElement && hasNextPage && !isFetching && !isLoadingRef.current) {
+            if (containerRefElement && hasNextPage && !isFetching) {
                 const {scrollHeight, scrollTop, clientHeight} = containerRefElement
 
                 // Увеличиваем порог и добавляем дополнительные проверки
@@ -60,17 +57,10 @@ export default function DataTable<T>({
                 const distanceFromBottom = scrollHeight - scrollTop - clientHeight;
 
                 if (distanceFromBottom < threshold) {
-                    isLoadingRef.current = true;
-
                     try {
                         await fetchNextPage();
                     } catch (error) {
                         console.error('Error fetching next page:', error);
-                    } finally {
-                        // Добавляем небольшую задержку перед разрешением новых запросов
-                        setTimeout(() => {
-                            isLoadingRef.current = false;
-                        }, 100);
                     }
                 }
             }
@@ -83,12 +73,6 @@ export default function DataTable<T>({
         fetchMoreOnBottomReached(e.currentTarget);
     }, [fetchMoreOnBottomReached]);
 
-    // Сбрасываем флаг при изменении состояния загрузки
-    useEffect(() => {
-        if (!isFetching) {
-            isLoadingRef.current = false;
-        }
-    }, [isFetching]);
     // Important: Keep the row virtualizer in the lowest component possible to avoid unnecessary re-renders.
     const rowVirtualizer = useVirtualizer<HTMLDivElement, HTMLTableRowElement>({
         count: rows.length,


### PR DESCRIPTION
This commit addresses an issue where the page would enter an infinite refresh cycle upon reaching the last page of a paginated view, sometimes rolling back to the first page.

Changes made:
1.  **Refined `getNextPageParam` in `src/app/(general)/queries.ts`**:
    *   Added detailed console logging to trace the values used in determining if a next page exists.
    *   Ensured `lastPage.count` is safely accessed, defaulting to 0 if null or undefined, to prevent calculation errors.

2.  **Improved Error Handling in `getBasicView` in `src/app/(general)/queries.ts`**:
    *   The function now checks for errors or null data from the Supabase query.
    *   If an error is detected, it returns a standardized structure (`{ data: [], count: 0, error: res.error }`) which signals to `useInfiniteQuery` that there's no more data or an error occurred, preventing further pagination attempts.

3.  **Simplified State Management in `DataTable` in `src/app/components/data-table/data-table.tsx`**:
    *   Removed the manual `isLoadingRef` and its associated logic (including a `setTimeout`).
    *   The component now relies solely on the `isFetching` and `hasNextPage` props from `useInfiniteQuery` to control the fetching of more data. This simplifies the logic and makes it less prone to race conditions.

These changes aim to make the lazy loading mechanism more robust, prevent unnecessary fetches when all data has been loaded or an error occurs, and eliminate the infinite refresh cycle.